### PR TITLE
Add new option for gigabyte support

### DIFF
--- a/free.1
+++ b/free.1
@@ -13,10 +13,10 @@
 .Op Fl s Ar delay
 .Nm
 .Fl m
-.Op Fl m Ar delay
+.Op Fl s Ar delay
 .Nm
 .Fl g
-.Op Fl g Ar delay
+.Op Fl s Ar delay
 .Nm
 .Fl Vh?
 .Sh DESCRIPTION

--- a/free.1
+++ b/free.1
@@ -15,6 +15,9 @@
 .Fl m
 .Op Fl m Ar delay
 .Nm
+.Fl g
+.Op Fl g Ar delay
+.Nm
 .Fl Vh?
 .Sh DESCRIPTION
 The
@@ -30,6 +33,8 @@ Display memory sizes in bytes.
 Display memory sizes in kilobytes (default if no options given).
 .It Fl m
 Display memory sizes in megabytes.
+.It Fl g
+Display memory sizes in gigabytes.
 .It Fl s Ar delay
 Sleep for
 .Ar delay

--- a/free.c
+++ b/free.c
@@ -50,13 +50,15 @@ int main(int argc, char **argv) {
     mach_msg_type_number_t memsz, vmsz;
 
     /* parse our command line options */
-    while ((c = getopt(argc, argv, "bkms:Vh?")) != -1) {
+    while ((c = getopt(argc, argv, "bkmgs:Vh?")) != -1) {
         if (c == 'b') {
             set_units(&units, BYTES);
         } else if (c == 'k') {
             set_units(&units, KILOBYTES);
         } else if (c == 'm') {
             set_units(&units, MEGABYTES);
+        } else if (c == 'g') {
+            set_units(&units, GIGABYTES);
         } else if (c == 's') {
             poll = atoi(optarg);
         } else if (c == 'V') {
@@ -110,7 +112,9 @@ int main(int argc, char **argv) {
         if (units == KILOBYTES) {
             div = 1024;
         } else if (units == MEGABYTES) {
-            div = 1048576;
+            div = 1048576;    // 1024 ^ 2
+        } else if (units == GIGABYTES) {
+            div = 1073741824; // 1024 ^ 3
         }
 
         /* we have collected data, put it into our structure */

--- a/free.h
+++ b/free.h
@@ -9,10 +9,10 @@
  * See COPYING.LIB for licensing details.
  */
 
-#define FREE_USAGE "Usage: %s [-b|-k|-m] [-s delay] [-V] [-h|-?]\n"
+#define FREE_USAGE "Usage: %s [-b|-k|-m|-g] [-s delay] [-V] [-h|-?]\n"
 #define COMBINED_UNIT_OPTIONS "You may only use one of the unit options:  -b, -k, or -m\n"
 
-enum { UNUSED_UNIT, BYTES, KILOBYTES, MEGABYTES };
+enum { UNUSED_UNIT, BYTES, KILOBYTES, MEGABYTES, GIGABYTES };
 
 typedef struct mem {
     uint64_t total;


### PR DESCRIPTION
I've add a new option `-g` to display memory usage in gigabytes (GB).
Like this:
```
➜  darwin-free git:(master) ./free -h
Usage: free [-b|-k|-m|-g] [-s delay] [-V] [-h|-?]
➜  darwin-free git:(master) ./free -g
             total       used       free     active   inactive      wired
Mem:            16         12          0          5          5          1
```